### PR TITLE
Override CAN_TRUNCATE_INPUT_DATA in GeometricGraphSampler

### DIFF
--- a/datasets/geometric_sampler.py
+++ b/datasets/geometric_sampler.py
@@ -3,6 +3,7 @@ from clrs._src.samplers import Sampler
 from clrs._src.specs import SPECS
 class GeometricGraphSampler(Sampler):
     """Bellman-Ford sampler."""
+    CAN_TRUNCATE_INPUT_DATA = True
 
     def _sample_data(
         self,


### PR DESCRIPTION
As can be seen [here](https://github.com/google-deepmind/clrs/blob/9850007a8164c61c9e92903f62f83830ef34d138/clrs/_src/samplers.py#L135-L142) it is necessary to override the `CAN_TRUNCATE_INPUT_DATA` attribute
Fixes #1 